### PR TITLE
fix(select): allow parse number values

### DIFF
--- a/source/functions/select.js
+++ b/source/functions/select.js
@@ -36,6 +36,10 @@ const cleanFirstSelectArg = (arg) => {
 
 // in: "second", out: second
 const cleanSecondSelectArg = (arg) => {
+  const possibleNumber = Number(arg);
+  if (!Number.isNaN(possibleNumber)) {
+    return possibleNumber;
+  }
   return arg.replace(/\"/g, '').trim();
 }
 

--- a/tests/select.test.js
+++ b/tests/select.test.js
@@ -38,4 +38,10 @@ describe('select', ()=> {
     let json = [{"id": "first", "val": 1}, {"id": "second", "val": 2}];
     expect(jaycue(json, filter)).toEqual(jq(json, filter));
   });
+
+  test('select by numerical value', () => {
+    let filter = '.[] | select(.val != 2) .id';
+    let json = [{"id": "first", "val": 1}, {"id": "second", "val": 2}];
+    expect(jaycue(json, filter)).toEqual(jq(json, filter));
+  });
 });


### PR DESCRIPTION
This MR allows you to select numerical values. Like for example an id.

```js
jq(
  {someKey: [{id: 1, name: 'Example 1'}, {id: 2, name: 'Example 2'}]},
  '.someKey | .[] | select(.id == 2) | .name'
)
```